### PR TITLE
拡張機能AsciiDocの発行者の変更

### DIFF
--- a/dev/pc-vscode.md
+++ b/dev/pc-vscode.md
@@ -59,7 +59,7 @@
 
 ### AsciiDoctor
 
-- AsciiDoc (by Joao Pinto)
+- AsciiDoc (by asciidoctor)
 
 ### LaTeX
 


### PR DESCRIPTION
Joao Pintoが発行者のAsciiDocという拡張機能が見つかりませんでした。関連していそうなJoao Pintoが発行者のasciidoctor-vscodeは廃止されており、asciidoctorを発行者としたAsciiDocという拡張機能へと誘導がされていました。おそらくここで示しているのはasciidoctorによるAsciiDocだと思ったのですがどうでしょうか。
拡張機能名と発行者の組み合わせが実際と違うと少し戸惑うので、マーケットプレイス上の表記に沿ったほうが良いのではないかと思った次第です。